### PR TITLE
Pass arbitrary arguments to cmake called inside Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,50 +29,51 @@
 # Provide current version here instead of versin.h.in file
 LETHEAN_VERSION?=4.0.1
 LETHEAN_RELEASE?=macOS
+LETHEAN_CMAKE_FLAGS?=""
 
 all: help
 
 cmake-debug:
 	mkdir -p build/$(LETHEAN_VERSION)/debug
-	cd build/$(LETHEAN_VERSION)/debug && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D CMAKE_BUILD_TYPE=Debug ../../..
+	cd build/$(LETHEAN_VERSION)/debug && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D CMAKE_BUILD_TYPE=Debug ../../..
 
 debug: cmake-debug
 	cd build/$(LETHEAN_VERSION)/debug && $(MAKE)
 
 debug-test:
 	mkdir -p build/$(LETHEAN_VERSION)/debug
-	cd build/$(LETHEAN_VERSION)/debug && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE) && $(MAKE) test
+	cd build/$(LETHEAN_VERSION)/debug && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE) && $(MAKE) test
 
 debug-all:
 	mkdir -p build/$(LETHEAN_VERSION)/debug
-	cd build/$(LETHEAN_VERSION)/debug && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/debug && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE)
 
 debug-static-all:
 	mkdir -p build/$(LETHEAN_VERSION)/debug
-	cd build/$(LETHEAN_VERSION)/debug && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D STATIC=ON -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/debug && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D STATIC=ON -D CMAKE_BUILD_TYPE=Debug ../../.. && $(MAKE)
 
 cmake-release:
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D CMAKE_BUILD_TYPE=Release ../../..
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D CMAKE_BUILD_TYPE=Release ../../..
 
 release: cmake-release
 	cd build/$(LETHEAN_VERSION)/release && $(MAKE)
 
 release-test:
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE) && $(MAKE) test
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE) && $(MAKE) test
 
 release-all:
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE)
 
 release-static: ## Linux 64 & Boost Compile
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release ../../.. && $(MAKE)
 
 coverage:
 	mkdir -p build/$(LETHEAN_VERSION)/debug
-	cd build/$(LETHEAN_VERSION)/debug && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug -D COVERAGE=ON ../../.. && $(MAKE) && $(MAKE) test
+	cd build/$(LETHEAN_VERSION)/debug && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug -D COVERAGE=ON ../../.. && $(MAKE) && $(MAKE) test
 
 # Targets for specific prebuilt builds which will be advertised for updates by their build tag
 
@@ -89,60 +90,60 @@ zip-release: ci-release # cd into packaged, zip a clean release file for an arti
 
 release-static-linux-armv6: ## arch: armv6zk
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv6zk" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv6" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv6zk" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv6" ../../.. && $(MAKE)
 
 release-static-linux-armv7: ## arch: armv7-a
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv7-a" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv7" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv7-a" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv7" ../../.. && $(MAKE)
 
 release-static-android: ## arch: armv7-a
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv7-a" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D ANDROID=true -D INSTALL_VENDORED_LIBUNBOUND=ON -D BUILD_TAG="android" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv7-a" -D STATIC=ON -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D ANDROID=true -D INSTALL_VENDORED_LIBUNBOUND=ON -D BUILD_TAG="android" ../../.. && $(MAKE)
 
 release-static-linux-armv8: ## arch: armv8-a
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv8-a" -D STATIC=ON -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv8" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D BUILD_TESTS=OFF -D ARCH="armv8-a" -D STATIC=ON -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-armv8" ../../.. && $(MAKE)
 
 release-static-linux-x86_64: ## Linux 64
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-x64" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-x64" ../../.. && $(MAKE)
 
 release-static-linux-x86_64-boost:
 	cd boost && ./bootstrap.sh && ./b2 --prefix=$(shell pwd)/deps --layout=system address-model=64 runtime-link=static link=static variant=release threading=multi --with-system --with-filesystem --with-thread --with-date_time --with-chrono --with-regex --with-serialization --with-program_options --with-atomic --with-locale install
 
 release-static-linux-x86_64-local-boost: release-static-linux-x86_64-boost
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D Boost_NO_SYSTEM_PATHS=TRUE -D BOOST_ROOT=$(shell pwd)/deps -D CMAKE_BUILD_TYPE=release -D Boost_NO_BOOST_CMAKE=ON -D BUILD_TAG="linux-x64" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D Boost_NO_SYSTEM_PATHS=TRUE -D BOOST_ROOT=$(shell pwd)/deps -D CMAKE_BUILD_TYPE=release -D Boost_NO_BOOST_CMAKE=ON -D BUILD_TAG="linux-x64" ../../.. && $(MAKE)
 
 release-static-freebsd-x86_64: ## FreeBSD 64
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="freebsd-x64" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="freebsd-x64" ../../.. && $(MAKE)
 
 release-static-mac-x86_64: ## macOS64-intel
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="mac-x64" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="mac-x64" ../../.. && $(MAKE)
 
 release-static-linux-i686: ## Linux32
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -D LETHEAN_VERSION=$(LETHEAN_VERSION)  -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-x86" ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -D LETHEAN_VERSION=$(LETHEAN_VERSION)  -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-x86" ../../.. && $(MAKE)
 
 release-static-win64: ## Windows64
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -G "MSYS Makefiles" -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=../../../cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -G "MSYS Makefiles" -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=../../../cmake/64-bit-toolchain.cmake $(LETHEAN_CMAKE_FLAGS) -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) ../../.. && $(MAKE)
 
 release-static-win64-boost: ## Windows64 & Boost Compile
 	cd boost && ./bootstrap.sh && ./b2 --prefix=$(shell cd ${MINGW_PREFIX} && pwd -W) --layout=system address-model=64 runtime-link=static link=static variant=release threading=multi --with-system --with-filesystem --with-thread --with-date_time --with-chrono --with-regex --with-serialization --with-program_options --with-atomic --with-locale install
 
 release-static-win32: ## Windows32
 	mkdir -p build/$(LETHEAN_VERSION)/release
-	cd build/$(LETHEAN_VERSION)/release && cmake -G "MSYS Makefiles" -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x32" -D CMAKE_TOOLCHAIN_FILE=../../../cmake/32-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) ../../.. && $(MAKE)
+	cd build/$(LETHEAN_VERSION)/release && cmake $(LETHEAN_CMAKE_FLAGS) -G "MSYS Makefiles" -D LETHEAN_VERSION=$(LETHEAN_VERSION) -D STATIC=ON -D ARCH="i686" -D BUILD_64=OFF -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x32" -D CMAKE_TOOLCHAIN_FILE=../../../cmake/32-bit-toolchain.cmake $(LETHEAN_CMAKE_FLAGS) -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) ../../.. && $(MAKE)
 
 docker-testnet: ## Run testnet Docker daemon
 	docker run -it lthn/chain:testnet
 
 fuzz:
 	mkdir -p build/fuzz
-	cd build/fuzz && cmake -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-gcc -D CMAKE_CXX_COMPILER=afl-g++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" ../.. && $(MAKE)
+	cd build/fuzz && cmake $(LETHEAN_CMAKE_FLAGS) -D BUILD_TESTS=ON -D USE_LTO=OFF -D CMAKE_C_COMPILER=afl-gcc -D CMAKE_CXX_COMPILER=afl-g++ -D ARCH="x86-64" -D CMAKE_BUILD_TYPE=fuzz -D BUILD_TAG="linux-x64" ../.. && $(MAKE)
 
 clean: ## Deletes build/LETHEAN_VERSION & deps/
 	@echo "WARNING: Back-up your wallet if it exists within ./build!" ; \


### PR DESCRIPTION
Now `LETHEAN_CMAKE_FLAGS` env variable can be used, to pass arguments to cmake.

For example building with boost in specific directory
```
LETHEAN_CMAKE_FLAGS='-D Boost_NO_SYSTEM_PATHS=TRUE -D BOOST_ROOT=something -D Boost_NO_BOOST_CMAKE=ON' make release-static-linux-x86_64 -j 2
```