### PR TITLE
Dev 12 documentation overhaul

### DIFF
--- a/.github/workflows/_on-pr-fast.yml
+++ b/.github/workflows/_on-pr-fast.yml
@@ -1,5 +1,6 @@
 name: PR Fast
-
+permissions:
+  contents: read
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/_on-pr.yml
+++ b/.github/workflows/_on-pr.yml
@@ -1,5 +1,6 @@
 name: PR
-
+permissions:
+  contents: read
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/_on-push.yml
+++ b/.github/workflows/_on-push.yml
@@ -1,5 +1,6 @@
 name: Push Full Build
-
+permissions:
+  contents: read
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/_on-push.yml
+++ b/.github/workflows/_on-push.yml
@@ -38,3 +38,6 @@ jobs:
     with:
       chain-network: ${{ github.ref_name == 'main' && 'mainnet' || 'testnet' }}
 
+  build-docs:
+    name: Docs
+    uses: ./.github/workflows/build-docs.yml

--- a/.github/workflows/_on-release.yml
+++ b/.github/workflows/_on-release.yml
@@ -1,5 +1,6 @@
 name: Push Full Build
-
+permissions:
+  contents: read
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,36 @@
+name: docs
+permissions:
+  contents: read
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v4
+        with:
+          key: ${{ github.ref }}
+          path: .cache
+      - run: sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev pngquant
+      - run: pip install mkdocs-git-revision-date-localized-plugin cairosvg mkdocs-git-committers-plugin-2 mkdocs-git-authors-plugin mkdocs-material[imaging]
+
+      - name: Build Offline Version
+        run: CI=true INSIDERS=false mkdocs build
+
+      - name: Zip Build
+        run: |
+          cd build/docs
+          zip -qq -r ../documentation.zip *
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Documentation
+          path: build/documentation.zip

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+
+      - name: Install Conan
+        uses: conan-io/setup-conan@v1
+        with:
+          home: ${{ github.workspace }}/build/sdk
+          cache_packages: true
+          
       - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - run: pip install mkdocs-git-revision-date-localized-plugin cairosvg mkdocs-git-committers-plugin-2 mkdocs-git-authors-plugin mkdocs-material[imaging]
 
       - name: Build Offline Version
-        run: CI=true INSIDERS=false mkdocs build
+        run: make docs
 
       - name: Zip Build
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          submodules: recursive
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
@@ -20,7 +21,7 @@ jobs:
         with:
           home: ${{ github.workspace }}/build/sdk
           cache_packages: true
-          
+
       - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "contrib/tor-connect"]
 	path = contrib/tor-connect
 	url = https://github.com/hyle-team/tor-connect.git
+[submodule "docs"]
+	path = docs
+	url = https://github.com/letheanVPN/documentation.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ message("OPENSSL_SSL_LIBRARY: ${OPENSSL_SSL_LIBRARY}")
 
 list(INSERT CMAKE_MODULE_PATH 0
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
+include(DocBuilder)
 
 if(POLICY CMP0043)
   cmake_policy(SET CMP0043 NEW)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Copyright (c) 2017-2025 Lethean https://lt.hn
 # Copyright (c) 2014-2019 Zano Project
 # Copyright (c) 2014 The Cryptonote developers
 # Distributed under the MIT/X11 software license, see the accompanying
@@ -53,36 +54,21 @@ CPU_CORES := $(or $(CPU_CORES),1)
 CPU_CORES := $(shell expr $(CPU_CORES) + 0 2>/dev/null || echo 1)
 CONAN_CPU_COUNT=$(CPU_CORES)
 
-ifneq ($(OS),Windows_NT)
-system := $(shell uname)
-ifneq (, $(findstring MINGW, $(system)))
-  cmake_gen = -G 'MSYS Makefiles'
-endif
-endif
 PROFILES := $(patsubst cmake/profiles/%,%,$(wildcard cmake/profiles/*))
 SORTED_PROFILES := $(sort $(PROFILES))
 CONAN_CACHE := $(CURDIR)/build/sdk
 DEFAULT_CONAN_PROFILE := $(CONAN_CACHE)/cmake/profiles/default
 
-cmake = cmake $(cmake_gen)
-
-cmake_debug = $(cmake) -D CMAKE_BUILD_TYPE=Debug
-cmake_release = $(cmake) -D CMAKE_BUILD_TYPE=Release
-
-cmake_gui = -D BUILD_GUI=ON
-cmake_static = -D STATIC=ON
-cmake_tests = -D BUILD_TESTS=ON
-
-# Helper macro
-define CMAKE
-  mkdir -p $1 && cd $1 && $2 ../../
-endef
-
-build = build
-dir_debug = $(build)/debug
-dir_release = $(build)/release
-
 all: help
+
+configure:
+	@echo "Running Config: release"
+	CONAN_HOME=$(CONAN_CACHE) conan install . --output-folder=build/release --build=missing -s build_type=Release
+	cmake -S . -B build/release -DCMAKE_TOOLCHAIN_FILE=build/release/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+
+docs: configure
+	@echo "Building Documentation"
+	cmake --build build/release --target=docs --config=Release --parallel=$(CPU_CORES)
 
 release: conan-profile-detect
 	@echo "Building profile: release"
@@ -152,4 +138,4 @@ clean:
 tags:
 	ctags -R --sort=1 --c++-kinds=+p --fields=+iaS --extra=+q --language-force=C++ src contrib tests/gtest
 
-.PHONY: all release debug static static-release gui gui-release gui-static gui-release-static gui-debug test test-release test-debug clean tags conan-profile-detect $(PROFILES)
+.PHONY: all release debug docs configure static static-release test test-release test-debug clean tags conan-profile-detect $(PROFILES)

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,7 @@ DEFAULT_CONAN_PROFILE := $(CONAN_CACHE)/cmake/profiles/default
 
 all: help
 
-configure:
-	@echo "Running Config: release"
-	CONAN_HOME=$(CONAN_CACHE) conan install . --output-folder=build/release --build=missing -s build_type=Release
-	cmake -S . -B build/release -DCMAKE_TOOLCHAIN_FILE=build/release/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
 
-docs: configure
-	@echo "Building Documentation"
-	cmake --build build/release --target=docs --config=Release --parallel=$(CPU_CORES)
 
 release: conan-profile-detect
 	@echo "Building profile: release"
@@ -132,10 +125,24 @@ test-debug:
 	cmake --build build/test-debug --config=Debug --parallel=$(CPU_CORES)
 	$(MAKE) test
 
+configure:
+	@echo "Running Config: release"
+	CONAN_HOME=$(CONAN_CACHE) conan install . --output-folder=build/release --build=missing -s build_type=Release
+	cmake -S . -B build/release -DCMAKE_TOOLCHAIN_FILE=build/release/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+
+docs: configure
+	@echo "Building Documentation"
+	cmake --build build/release --target=docs --config=Release --parallel=$(CPU_CORES)
+
+docs-dev: configure
+	@echo "Building Documentation"
+	cmake --build build/release --target=serve_docs --config=Release
+
+
 clean:
 	rm -rf build
 
 tags:
 	ctags -R --sort=1 --c++-kinds=+p --fields=+iaS --extra=+q --language-force=C++ src contrib tests/gtest
 
-.PHONY: all release debug docs configure static static-release test test-release test-debug clean tags conan-profile-detect $(PROFILES)
+.PHONY: all release debug docs docs-dev configure static static-release test test-release test-debug clean tags conan-profile-detect $(PROFILES)

--- a/cmake/DocBuilder.cmake
+++ b/cmake/DocBuilder.cmake
@@ -25,3 +25,22 @@ add_custom_target(install-docs
         DEPENDS docs
         COMMAND "${CMAKE_COMMAND}" --install . --component docs
         COMMENT "Installing documentation")
+
+# Name of the target that launches the dev server
+add_custom_target(
+        serve_docs                     # ← invoke with `make serve_docs`
+        COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
+        # On Windows we need to run the command through the shell
+        # so that the `&&` operator works correctly.
+        ${CMAKE_COMMAND} -E env
+        mkdocs serve
+        --dev-addr "127.0.0.1:8000"      # optional – explicit bind address
+        --watch "${MKDOCS_SRC}" # watch source files for changes
+        --config-file "${MKDOCS_SRC}/mkdocs.yml"
+        WORKING_DIRECTORY "${MKDOCS_SRC}"
+        USES_TERMINAL                  # tells CMake to attach the child process to the console
+        COMMENT "Starting MkDocs live‑preview server (Ctrl‑C to stop)"
+        VERBATIM
+)
+
+add_dependencies(serve_docs docs)   # ensures the static site is up‑to‑date before serving

--- a/cmake/DocBuilder.cmake
+++ b/cmake/DocBuilder.cmake
@@ -1,0 +1,27 @@
+set(MKDOCS_SRC "${CMAKE_SOURCE_DIR}/docs")
+set(MKDOCS_OUT "${CMAKE_BINARY_DIR}/../docs")
+
+message("MKDocs src: ${MKDOCS_SRC} > ${MKDOCS_OUT}")
+
+file(MAKE_DIRECTORY "${MKDOCS_OUT}")
+
+add_custom_target(docs
+        COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
+        mkdocs build
+        --clean
+        --site-dir "${MKDOCS_OUT}"
+        --config-file "${MKDOCS_SRC}/mkdocs.yml"
+        WORKING_DIRECTORY "${MKDOCS_SRC}"
+        COMMENT "Generating documentation with MkDocs"
+        VERBATIM
+)
+
+# Optional install step
+install(DIRECTORY "${MKDOCS_OUT}/"
+        DESTINATION "share/doc/${PROJECT_NAME}"
+        COMPONENT docs)
+
+add_custom_target(install-docs
+        DEPENDS docs
+        COMMAND "${CMAKE_COMMAND}" --install . --component docs
+        COMMENT "Installing documentation")


### PR DESCRIPTION
This pull request introduces a new documentation build and serve system using MkDocs, integrates it into the build workflow, and adds the documentation as a submodule. The main themes are documentation management and build system improvements.

**Documentation Management:**
* Added the `docs` submodule pointing to the official documentation repository, allowing the project to track and update documentation separately. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R10-R12) [[2]](diffhunk://#diff-46b42b4229cd7a39c564e780bb665a8bde4fdf722007e8473f167fe53ed4b995R1)
* Created `cmake/DocBuilder.cmake` to automate building, installing, and serving documentation with MkDocs, including targets for static builds and live previews.

**Build System Improvements:**
* Updated `Makefile` to add new targets for building and serving documentation (`docs`, `docs-dev`, and `configure`), integrating them into the existing build workflow.
* Included the new `DocBuilder` CMake module in `CMakeLists.txt`, enabling documentation-related build targets.
* Minor copyright update in `Makefile`.