### PR TITLE
Add CMake and Conan presets, update build config

### DIFF
--- a/.github/workflows/_on-pr.yml
+++ b/.github/workflows/_on-pr.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-windows-intel.yml
+++ b/.github/workflows/build-windows-intel.yml
@@ -70,7 +70,7 @@ jobs:
       - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-git-committers-plugin-2 mkdocs-git-authors-plugin "mkdocs-material[imaging]"
 
       - name: Compile Release
-        run: make release CPU_CORES=4 TESTNET=${{ inputs.chain-network == 'testnet' && '1' || '0' }}
+        run: make release PRESET_CONFIGURE=conan-default CPU_CORES=4 TESTNET=${{ inputs.chain-network == 'testnet' && '1' || '0' }}
 
       - name: CLI Artifacts
         uses: ./.github/actions/upload-artifacts

--- a/.github/workflows/build-windows-intel.yml
+++ b/.github/workflows/build-windows-intel.yml
@@ -70,7 +70,7 @@ jobs:
       - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-git-committers-plugin-2 mkdocs-git-authors-plugin "mkdocs-material[imaging]"
 
       - name: Compile Release
-        run: make release PRESET_CONFIGURE=conan-default CPU_CORES=4 TESTNET=${{ inputs.chain-network == 'testnet' && '1' || '0' }}
+        run: make release CPU_CORES=4 TESTNET=${{ inputs.chain-network == 'testnet' && '1' || '0' }}
 
       - name: CLI Artifacts
         uses: ./.github/actions/upload-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ Thumbs.db
 .idea/dictionaries
 .idea/shelf
 .idea/copilot*
+.idea/modules.xml
+.idea/*.iml
 .vs/*
 CMakeUserPresets.json

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 virtualenv at $PROJECT_DIR$.venv" />
+  </component>
+  <component name="CMakePythonSetting">
+    <option name="pythonIntegrationState" value="YES" />
+  </component>
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
   <component name="CidrRootsConfiguration">
     <excludeRoots>
       <file path="$PROJECT_DIR$/build" />
@@ -9,6 +16,7 @@
   <component name="MakefileSettings">
     <option name="linkedExternalProjectsSettings">
       <MakefileProjectSettings>
+        <option name="buildOptions" value="--jobs=30" />
         <option name="buildTarget" value="build" />
         <option name="cleanTarget" value="clean-build" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -23,8 +31,4 @@
     </option>
   </component>
   <component name="MakefileWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
-  <component name="CMakePythonSetting">
-    <option name="pythonIntegrationState" value="YES" />
-  </component>
-  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,6 @@ message(STATUS "Using Boost ${Boost_VERSION} from Conan")
 
 find_package(miniupnpc REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(ethash REQUIRED)
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 include_directories(src "${CMAKE_BINARY_DIR}/version")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,98 @@
+{
+  "version": 10,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "$comment": "Lethean presets",
+  "include": [
+    "ConanPresets.json"
+
+  ],
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build using Ninja generator",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/default",
+      "cacheVariables": {
+        "TESTNET": "ON"
+      }
+    },
+    {
+      "name": "windows-default",
+      "displayName": "Windows x64 Debug",
+      "description": "Sets Ninja generator, compilers, x64 architecture, build and install directory, debug build type",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "TESTNET": "ON",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/install/${presetName}"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Windows" ]
+        }
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": true}
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "generators": [
+        "TGZ",
+        "ZIP"
+      ]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "default",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "default"
+        },
+        {
+          "type": "build",
+          "name": "default"
+        },
+        {
+          "type": "test",
+          "name": "default"
+        },
+        {
+          "type": "package",
+          "name": "default"
+        }
+      ]
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,11 +1,10 @@
 {
-  "version": 10,
+  "version": 8,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 23,
     "patch": 0
   },
-  "$comment": "Lethean presets",
   "include": [
     "ConanPresets.json"
 
@@ -22,7 +21,7 @@
       }
     },
     {
-      "name": "windows-default",
+      "name": "windows-defaultss",
       "displayName": "Windows x64 Debug",
       "description": "Sets Ninja generator, compilers, x64 architecture, build and install directory, debug build type",
       "generator": "Ninja",

--- a/ConanPresets.json
+++ b/ConanPresets.json
@@ -1,0 +1,8 @@
+{
+    "version": 4,
+    "vendor": {
+        "conan": {}
+    },
+    "include": [
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release: docs build
 	@rm -rf $(CURDIR)/build/packages/_CPack_Packages
 
 build: configure
-	cmake --build $(BUILD_FOLDER) --config=$(BUILD_TYPE) --parallel=$(CPU_CORES)
+	cmake --build --preset conan-release --parallel=$(CPU_CORES)
 
 debug: conan-profile-detect
 	@echo "Building profile: debug"
@@ -92,7 +92,7 @@ build-deps: conan-profile-detect
 
 configure: build-deps
 	@echo "Running Configure: $(BUILD_TYPE) testnet=$(TESTNET)"
-	cmake -S . -B $(BUILD_FOLDER) -DCMAKE_TOOLCHAIN_FILE=$(BUILD_FOLDER)/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
+	cmake --preset conan-default -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
 
 docs: configure
 	@echo "Building Documentation"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ STATIC:= 0
 BUILD_TYPE ?=Release
 BUILD_VERSION:=6.0.1
 BUILD_FOLDER:=build/release
+PRESET_BUILD:=conan-release
+PRESET_CONFIGURE:=conan-release
 
 # -----------------------------------------------------------------
 # Unix‑like systems (Linux, macOS, *BSD, etc.)
@@ -77,14 +79,7 @@ release: docs build
 	@rm -rf $(CURDIR)/build/packages/_CPack_Packages
 
 build: configure
-	cmake --build --preset conan-release --parallel=$(CPU_CORES)
-
-debug: conan-profile-detect
-	@echo "Building profile: debug"
-	CONAN_HOME=$(CONAN_CACHE) $(CONAN_EXECUTABLE) install . --build=missing -s build_type=Debug
-	cmake -S . -B $(CURDIR)/build/debug -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/build/debug/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DTESTNET=$(TESTNET)
-	cmake --build $(CURDIR)/build/debug --config=Debug --parallel=$(CPU_CORES)
-
+	cmake --build --preset $(PRESET_BUILD) --parallel=$(CPU_CORES)
 
 build-deps: conan-profile-detect
 	@echo "Build Dependencies: $(BUILD_TYPE) testnet=$(TESTNET)"
@@ -92,7 +87,7 @@ build-deps: conan-profile-detect
 
 configure: build-deps
 	@echo "Running Configure: $(BUILD_TYPE) testnet=$(TESTNET)"
-	cmake --preset conan-release -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
+	cmake --preset $(PRESET_CONFIGURE) -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
 
 docs: configure
 	@echo "Building Documentation"
@@ -165,4 +160,4 @@ clean-build:
 tags:
 	ctags -R --sort=1 --c++-kinds=+p --fields=+iaS --extra=+q --language-force=C++ src contrib tests/gtest
 
-.PHONY: all release upload-conan-cache docker-chain-node debug docs docs-dev configure static static-release test test-release test-debug clean tags conan-profile-detect get-conan $(PROFILES)
+.PHONY: all release upload-conan-cache docs docs-dev configure static static-release test test-release test-debug clean tags conan-profile-detect get-conan $(PROFILES)

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build-deps: conan-profile-detect
 
 configure: build-deps
 	@echo "Running Configure: $(BUILD_TYPE) testnet=$(TESTNET)"
-	cmake --preset conan-default -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
+	cmake --preset conan-release -DSTATIC=$(STATIC) -DTESTNET=$(TESTNET) -DBUILD_VERSION=$(BUILD_VERSION)
 
 docs: configure
 	@echo "Building Documentation"

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ BUILD_FOLDER:=build/release
 PRESET_BUILD:=conan-release
 PRESET_CONFIGURE:=conan-release
 
-# -----------------------------------------------------------------
-# Unix‑like systems (Linux, macOS, *BSD, etc.)
-# -----------------------------------------------------------------
 UNAME_S := $(shell uname -s 2>/dev/null || echo Unknown)
 
 ifeq ($(UNAME_S),Linux)
@@ -40,10 +37,10 @@ ifeq ($(filter %BSD,$(UNAME_S)),%BSD)
     CPU_CORES := $(shell sysctl -n hw.ncpu 2>/dev/null || echo 1)
 endif
 
-# -----------------------------------------------------------------
-# Windows (detected by the built‑in $(OS) variable set by GNU make)
-# -----------------------------------------------------------------
 ifeq ($(OS),Windows_NT)
+
+PRESET_CONFIGURE:=conan-default
+
     # Prefer the environment variable that Windows sets for us.
     # It works in both cmd.exe and PowerShell.
     CPU_CORES := $(NUMBER_OF_PROCESSORS)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,6 +1,6 @@
 
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel" OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CPACK_PACKAGE_NAME "${package_name}")
     set(CPACK_PACKAGE_VENDOR "${package_vendor}")
     set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${package_description}")
@@ -26,8 +26,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
       #      message(STATUS "Registered CPACK_GENERATOR: productbuild")
         endif ()
     elseif(WIN32)
-      #  set(CPACK_GENERATOR "WIX")
-      #  message(STATUS "Registered CPACK_GENERATOR: WIX")
+#         set(CPACK_GENERATOR "WIX")
+#         message(STATUS "Registered CPACK_GENERATOR: WIX")
 #        set(CPACK_WIX_PRODUCT_ICON "${CMAKE_SOURCE_DIR}/resources/windows_icon.ico")
 #        set(CPACK_WIX_LICENSE_RTF "${CMAKE_SOURCE_DIR}/LICENSE.rtf")
 #        set(CPACK_WIX_UPGRADE_GUID "D3F5A9C1-4B2E-4F5A-9C71-123456789ABC") # change once per major version

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,12 +32,10 @@ class BlockchainConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
 
-        # When conan-default / conan-release becomes an issue the blow adds OS, ARCH and Compiler to the preset name
-        # if self.options.__contains__("CI"):
-        #     os_val = str(self.settings.os).lower()
-        #     arch_val = str(self.settings.arch).lower()
-        #     compiler_val = str(self.settings.compiler).lower()
-        #     tc.presets_prefix = f"{os_val}-{arch_val}-{compiler_val}"
+        os_val = str(self.settings.os).lower()
+        # arch_val = str(self.settings.arch).lower()
+        # compiler_val = str(self.settings.compiler).lower()
+        # tc.presets_prefix = f"{os_val}"
 
         tc.user_presets_path = "ConanPresets.json"
         tc.variables["STATIC"] = self.options.static
@@ -50,10 +48,15 @@ class BlockchainConan(ConanFile):
         deps.generate()
 
     def layout(self):
-
-        self.folders.generators = os.path.join("build", str(self.settings.build_type).lower(), "generators")
-        self.folders.build = os.path.join("build", str(self.settings.build_type).lower())
-        # self.folders.build_folder_vars = ["settings.os", "settings.arch", "settings.compiler", "settings.build_type"]
+        if self.settings.compiler == "msvc":
+            # For multi-config, all configurations go into the same "build" folder.
+            self.folders.build = "build/release"
+            self.folders.generators = "build/release/generators"
+        else:
+            # For single-config, we create a subfolder for each build type.
+            build_type_str = str(self.settings.build_type).lower()
+            self.folders.build = os.path.join("build", build_type_str)
+            self.folders.generators = os.path.join(self.folders.build, "generators")
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,11 +11,13 @@ class BlockchainConan(ConanFile):
 
     options = {
         "static": [True, False],
-        "testnet": [True, False]
+        "testnet": [True, False],
+        "ci": [True, False]
     }
     default_options = {
         "static": False,
         "testnet": False,
+        "ci": False,
         "boost/*:without_test": True
     }
 
@@ -29,7 +31,15 @@ class BlockchainConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.user_presets_path = False
+
+        # When conan-default / conan-release becomes an issue the blow adds OS, ARCH and Compiler to the preset name
+        # if self.options.__contains__("CI"):
+        #     os_val = str(self.settings.os).lower()
+        #     arch_val = str(self.settings.arch).lower()
+        #     compiler_val = str(self.settings.compiler).lower()
+        #     tc.presets_prefix = f"{os_val}-{arch_val}-{compiler_val}"
+
+        tc.user_presets_path = "ConanPresets.json"
         tc.variables["STATIC"] = self.options.static
         tc.variables["TESTNET"] = self.options.testnet
         # tc.preprocessor_definitions["TESTNET"] = None
@@ -40,8 +50,10 @@ class BlockchainConan(ConanFile):
         deps.generate()
 
     def layout(self):
+
         self.folders.generators = os.path.join("build", str(self.settings.build_type).lower(), "generators")
         self.folders.build = os.path.join("build", str(self.settings.build_type).lower())
+        # self.folders.build_folder_vars = ["settings.os", "settings.arch", "settings.compiler", "settings.build_type"]
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
This pull request introduces several improvements to the project's build configuration, focusing on modernizing and streamlining the CMake and Conan integration, as well as updating IDE and Makefile settings. The changes enhance the build workflow by adding CMake and Conan preset files, updating the Makefile to use these presets, and refining Conan options and toolchain generation.

**Build system modernization and workflow improvements:**

* Added `CMakePresets.json` and `ConanPresets.json` to the project, enabling standardized and simplified configuration, build, test, and packaging workflows using CMake and Conan presets. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R1-R98) [[2]](diffhunk://#diff-7a553e302253cd831fa539a9529fbc9ca4ec048b1d4577a81e507719157d0b0bR1-R8)
* Updated the `Makefile` to use CMake presets for building and configuring, replacing manual command-line options with `--preset conan-release` and `--preset conan-default` for more consistent builds. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L80-R80) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L95-R95)

**Conan configuration enhancements:**

* Added a `ci` option to the `BlockchainConan` class in `conanfile.py`, and set up default options for it.
* Modified the `generate` method in `conanfile.py` to use `ConanPresets.json` for user presets path, with comments for future extension to OS/ARCH/Compiler-specific presets.
* Improved the `layout` method in `conanfile.py` for better folder structure, with commented options for more granular build folder variables.

**IDE and build tool configuration updates:**

* Updated `.idea/misc.xml` to add components for Black, CMake, and Makefile integration, and set Makefile build options for parallel jobs. [[1]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229R3-R9) [[2]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229R19) [[3]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229L26-L29)

**Dependency and configuration cleanup:**

* Introduces CMakePresets.json and ConanPresets.json for standardized build configuration. Updates Makefile to use CMake presets, modifies .gitignore for IDE files, and refines conanfile.py to support CI option and preset integration.